### PR TITLE
Fix the hostname of the mapit server we use

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,10 +55,10 @@ Imminence::Application.configure do
 
   Geogov.configure do |g|
     g.provider_for :centre_of_country,             Geogov::Geonames.new
-    g.provider_for :centre_of_district,            Geogov::Mapit.new("http://mapit.alpha.gov.uk")
-    g.provider_for :areas_for_stack_from_postcode, Geogov::Mapit.new("http://mapit.alpha.gov.uk")
-    g.provider_for :areas_for_stack_from_coords,   Geogov::Mapit.new("http://mapit.alpha.gov.uk")
-    g.provider_for :lat_lon_from_postcode,         Geogov::Mapit.new("http://mapit.alpha.gov.uk")
+    g.provider_for :centre_of_district,            Geogov::Mapit.new("http://mapit.production.alphagov.co.uk")
+    g.provider_for :areas_for_stack_from_postcode, Geogov::Mapit.new("http://mapit.production.alphagov.co.uk")
+    g.provider_for :areas_for_stack_from_coords,   Geogov::Mapit.new("http://mapit.production.alphagov.co.uk")
+    g.provider_for :lat_lon_from_postcode,         Geogov::Mapit.new("http://mapit.production.alphagov.co.uk")
   end
 
   config.lograge.enabled = true


### PR DESCRIPTION
It turns out that our original Mapit server died in Amazon, so I have provisioned a new one:

http://mapit.production.alphagov.co.uk/

This IP is overridden in the hosts file to point to the internal address of the machine. Merging this commit will change Imminence to point to that new IP and geocoding should start working (I hope). Even if puppet hasn't made it appear in the hosts file yet, it is in DNS so it will work fine versus the public URL.

Once Imminence is deployed with this change everywhere, I can work on actually load-balancing it in Skyscape so we have more than one mapit box ;)
