### PR TITLE
Bump dependency versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'formtastic-bootstrap', git: 'https://github.com/cgunther/formtastic-bootstr
 gem 'jquery-rails'
 gem 'less-rails-bootstrap'
 
+gem 'gds-api-adapters', '4.1.3'
 gem 'govuk_content_models', '2.5.0'
 gem 'statsd-ruby', '1.0.0', :require => 'statsd'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,6 +293,7 @@ DEPENDENCIES
   faraday (= 0.8.1)
   formtastic!
   formtastic-bootstrap!
+  gds-api-adapters (= 4.1.3)
   gds-sso (= 2.1.0)
   geogov (= 0.0.9)
   govspeak (~> 1.2)


### PR DESCRIPTION
Bumping the versions of govuk_content_models and gds-api-adapters, to ease the transition to new plek.
