### PR TITLE
Fix geocoder cron

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,5 @@
 set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
-job_type :run_script, 'cd :path && /usr/local/bin/govuk_setenv imminence bundle exec script/:task'
+job_type :run_script, 'cd :path && /usr/local/bin/govuk_setenv imminence bundle exec script/:task :output'
 
 every 15.minutes do
   run_script "geocoder"


### PR DESCRIPTION
The cron task which generates the geocode data is not working, because it is not setting the environment variables that Plek >= 1.0.0 needs.

Additionally output was not going to the standard cron.log/cron.error.log.
