### PR TITLE
Correctly display timestamps

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,3 +31,4 @@ class CachedUrlTask < Rake::TaskLib
 end
 
 Imminence::Application.load_tasks
+task :default => [:test, :check_for_bad_time_handling]

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -8,6 +8,6 @@ class Action
   field :approved,     :type => DateTime
   field :comment,      :type => String
   field :request_type, :type => String
-  field :created_at, :type => DateTime, :default => lambda { Time.now }
+  field :created_at, :type => DateTime, :default => lambda { Time.zone.now }
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module Imminence
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'London'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -2,11 +2,13 @@ development:
   host: localhost
   database: imminence_development
   autocreate_indexes: true
+  use_activesupport_time_zone: true
 
 test:
   host: localhost
   database: imminence_test
   autocreate_indexes: true
+  use_activesupport_time_zone: true
 
 # set these environment variables on your prod server
 production:
@@ -15,6 +17,7 @@ production:
   username: <%= ENV['MONGOID_USERNAME'] %>
   password: <%= ENV['MONGOID_PASSWORD'] %>
   database: <%= ENV['MONGOID_DATABASE'] %>
+  use_activesupport_time_zone: true
   # slaves:
   #   - host: slave1.local
   #     port: 27018

--- a/lib/tasks/check_for_bad_time_handling.rake
+++ b/lib/tasks/check_for_bad_time_handling.rake
@@ -1,0 +1,25 @@
+task :check_for_bad_time_handling do
+  directories = Dir.glob(File.join(Rails.root, '**', '*.rb'))
+  matching_files = directories.select do |filename|
+    match = false
+    File.open(filename) do |file|
+      match = file.grep(%r{Time\.(now|utc|parse)}).any?
+    end
+    match
+  end
+  if matching_files.any?
+    raise <<-MSG
+
+Avoid issues with daylight-savings time by always building instances of
+TimeWithZone and not Time. Use methods like:
+    Time.zone.now, Time.zone.parse, n.days.ago, m.hours.from_now, etc
+
+in preference to methods like:
+    Time.now, Time.utc, Time.parse, etc
+
+Files that contain bad Time handling:
+  #{matching_files.join("\n  ")}
+
+MSG
+  end
+end


### PR DESCRIPTION
Correctly display timestamps in the user's timezone (GMT or BST, not UTC).

Related: https://github.com/alphagov/alphagov-deployment/pull/119
