### PR TITLE
Disable debug in geocoder script

### DIFF
--- a/script/geocoder
+++ b/script/geocoder
@@ -15,7 +15,6 @@ class Lockfile
     end
 end
 
-Lockfile.debug = true
 Lockfile.new lock_path, :retries => 0 do
   Service.all.each do |service|
     service.data_sets.each do |set|


### PR DESCRIPTION
Looks like it was added to help in initial development:
https://github.com/alphagov/imminence/commit/cb0580f816e7a0fbcd9052f9b8a01e423e0ffcd1

This, along with other things being fixed, is writing to `STDOUT` on every run and so is causing unwanted emails to be sent, which is making @samjsharpe sad.
