### PR TITLE
Set override lat/lng when given them in the csv

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -260,7 +260,7 @@ class Place
     location_parameters = if row['location']
       {location: PointField.new.deserialize(row['location'])}
     elsif row['lng'] && row['lat']
-      {location: Point.new(longitude: row['lng'], latitude: row['lat'])}
+      {override_lng: row['lng'], override_lat: row['lat']}
     else
       {}
     end

--- a/test/fixtures/good_csv_mixed_lat_lng.csv
+++ b/test/fixtures/good_csv_mixed_lat_lng.csv
@@ -1,0 +1,3 @@
+name,address1,address2,town,postcode,access_notes,general_notes,url,email,phone,fax,text_phone,lat,lng
+1 On 1 Rider Training Ltd,Faldo Farm,Faldo Road,Barton le Clay,MK45 4RF,,,http://www.1on1ridertrainingltd.co.uk,info@1on1ridertrainingltd.co.uk,,07983 815 388,,,
+1 Stop Instruction,Power League,Forest Road,Ilford (Fairlop),IG6 3HJ,Some access notes,Some general notes,http://www.1stopinstruction.com,info@1stopinstruction.com,0800 848 8418,0800 848 8419,0800 848 8420,51.599123456789,0.10033123456789

--- a/test/fixtures/good_csv_with_lat_lng.csv
+++ b/test/fixtures/good_csv_with_lat_lng.csv
@@ -1,0 +1,2 @@
+name,address1,address2,town,postcode,access_notes,general_notes,url,email,phone,fax,text_phone,lat,lng
+1 Stop Instruction,Power League,Forest Road,Ilford (Fairlop),IG6 3HJ,Some access notes,Some general notes,http://www.1stopinstruction.com,info@1stopinstruction.com,0800 848 8418,0800 848 8419,0800 848 8420,51.599123456789,0.10033123456789

--- a/test/integration/admin/data_set_create_edit_test.rb
+++ b/test/integration/admin/data_set_create_edit_test.rb
@@ -1,0 +1,95 @@
+require_relative '../../integration_test_helper'
+require 'gds_api/test_helpers/mapit'
+
+class DataSetCreateEditTest < ActionDispatch::IntegrationTest
+  include GdsApi::TestHelpers::Mapit
+
+  context "adding a data_set to a service" do
+    setup do
+      create_test_user
+      @service = FactoryGirl.create(:service)
+    end
+
+    should "create a data_set from csv and geocode postcodes" do
+      mapit_has_a_postcode("IG6 3HJ", [51.59918278577261, 0.10033740198112132])
+
+      visit "/admin/services/#{@service.id}"
+
+      within "#new-data" do
+        attach_file "Data file", fixture_file_path("good_csv.csv")
+        click_button "Create Data set"
+      end
+
+      run_all_delayed_jobs
+
+      @service.reload
+      assert_equal 2, @service.data_sets.count
+
+      ds = @service.latest_data_set
+      assert_equal 1, ds.places.count
+
+      place = ds.places.first
+
+      assert_equal 51.59918278577261, place.lat
+      assert_equal 0.10033740198112132, place.lng
+    end
+
+    should "take override lat/lon from csv if present" do
+      mapit_has_a_postcode("IG6 3HJ", [51.59918278577261, 0.10033740198112132])
+
+      visit "/admin/services/#{@service.id}"
+
+      within "#new-data" do
+        attach_file "Data file", fixture_file_path("good_csv_with_lat_lng.csv")
+        click_button "Create Data set"
+      end
+
+      run_all_delayed_jobs
+
+      @service.reload
+      assert_equal 2, @service.data_sets.count
+
+      ds = @service.latest_data_set
+      assert_equal 1, ds.places.count
+
+      place = ds.places.first
+
+      assert_equal 51.599123456789, place.override_lat
+      assert_equal 0.10033123456789, place.override_lng
+      assert_equal 51.599123456789, place.lat
+      assert_equal 0.10033123456789, place.lng
+    end
+
+    should "use postcode if lat/lng in csv is blank" do
+      mapit_has_a_postcode("MK45 4RF", [51.96876977095302, -0.4343681877525634])
+      mapit_has_a_postcode("IG6 3HJ", [51.59918278577261, 0.10033740198112132])
+
+      visit "/admin/services/#{@service.id}"
+
+      within "#new-data" do
+        attach_file "Data file", fixture_file_path("good_csv_mixed_lat_lng.csv")
+        click_button "Create Data set"
+      end
+
+      run_all_delayed_jobs
+
+      @service.reload
+      assert_equal 2, @service.data_sets.count
+
+      ds = @service.latest_data_set
+      assert_equal 2, ds.places.count
+
+      place = ds.places.first
+      assert_equal 51.96876977095302, place.lat
+      assert_equal -0.4343681877525634, place.lng
+      assert_nil place.override_lat
+      assert_nil place.override_lng
+
+      place = ds.places.last
+      assert_equal 51.599123456789, place.lat
+      assert_equal 0.10033123456789, place.lng
+      assert_equal 51.599123456789, place.override_lat
+      assert_equal 0.10033123456789, place.override_lng
+    end
+  end
+end

--- a/test/integration/admin/place_create_edit_test.rb
+++ b/test/integration/admin/place_create_edit_test.rb
@@ -3,7 +3,6 @@ require_relative '../../integration_test_helper'
 class PlaceCreateEditTest < ActionDispatch::IntegrationTest
 
   setup do
-    @controller = Admin::PlacesController
     GDS::SSO.test_user = FactoryGirl.create(:user)
     GdsApi::Mapit.any_instance.stubs(:location_for_postcode).returns(nil)
     @service = FactoryGirl.create(:service)

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -16,6 +16,14 @@ class ActionDispatch::IntegrationTest
     Capybara.use_default_driver
   end
 
+  def assert_current_url(path_with_query, options = {})
+    expected = URI.parse(path_with_query)
+    current = URI.parse(current_url)
+    assert_equal expected.path, current.path
+    unless options[:ignore_query]
+      assert_equal Rack::Utils.parse_query(expected.query), Rack::Utils.parse_query(current.query)
+    end
+  end
 end
 
 require 'capybara/poltergeist'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,6 +46,10 @@ class ActiveSupport::TestCase
     @controller.unstub(:authenticate_user!)
   end
 
+  def create_test_user
+    FactoryGirl.create(:user)
+  end
+
   def fixture_file_path(basename)
     Rails.root.join("test", "fixtures", basename)
   end


### PR DESCRIPTION
This will prevent these lat/lng co-ordinates being overwritten if the postcode is edited after import etc.
