### PR TITLE
Change how FileVerifier shells out to 'file'

### DIFF
--- a/lib/imminence/file_verifier.rb
+++ b/lib/imminence/file_verifier.rb
@@ -19,9 +19,7 @@ module Imminence
     end
 
     def mime_type
-      shell_result = IO.popen(["file", "--brief", "--mime-type", filename],
-        in: :close, err: :close)
-      shell_result.read.chomp
+      `file --brief --mime-type #{filename.shellescape}`.chomp
     end
 
     def is_mime_type?(comparison_mime_type)


### PR DESCRIPTION
Using the non-block form of IO.popen without calling close can leave
zombie processes around (see https://www.ruby-forum.com/topic/62435).
