### PR TITLE
Bump therubyracer to 0.11.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'delayed_job', '3.0.5'
 gem 'delayed_job_mongoid', '1.1.0'
 
 group :assets do
-  gem "therubyracer", "~> 0.9.4"
+  gem "therubyracer", "0.11.4"
   gem 'uglifier'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       less (~> 2.2.0)
     less-rails-bootstrap (2.2.0)
       less-rails (~> 2.2.0)
-    libv8 (3.3.10.4)
+    libv8 (3.11.8.17)
     libwebsocket (0.1.7.1)
       addressable
       websocket
@@ -241,6 +241,7 @@ GEM
     rake (10.0.3)
     rdoc (3.12.2)
       json (~> 1.4)
+    ref (1.0.5)
     responders (0.6.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -270,8 +271,9 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     statsd-ruby (1.0.0)
-    therubyracer (0.9.10)
-      libv8 (~> 3.3.10)
+    therubyracer (0.11.4)
+      libv8 (~> 3.11.8.12)
+      ref
     thor (0.17.0)
     tilt (1.3.6)
     timecop (0.5.9.2)
@@ -340,7 +342,7 @@ DEPENDENCIES
   simplecov (= 0.6.4)
   simplecov-rcov (= 0.2.3)
   statsd-ruby (= 1.0.0)
-  therubyracer (~> 0.9.4)
+  therubyracer (= 0.11.4)
   timecop (= 0.5.9.2)
   uglifier
   unicorn (= 4.3.1)


### PR DESCRIPTION
This is to get the app working on Precise. The older version of libv8
that 0.9.4 depends on isn't compatible.
