### PR TITLE
Index the geocoding-related scopes

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -49,7 +49,10 @@ class Place
     end
   end
 
-  scope :needs_geocoding, where(:location => nil, :geocode_error.exists => false)
+  # Match documents with either no geocode error or a null value. Changed so
+  # that anything without a location (or with a null location) is either
+  # matched by `needs_geocoding` or `with_geocoding_errors`.
+  scope :needs_geocoding, where(:location => nil, :geocode_error => nil)
 
   # We use "not null" here instead of "exists", because it works with the index
   scope :with_geocoding_errors, where(:geocode_error.ne => nil)


### PR DESCRIPTION
These were previously scanning through a few tens of thousands of places to find the ones needing geocoding.

The `with_geocoding_errors` scope is also tweaked to use a non-null check, rather than an existence check, so it can use the index too. Strictly speaking, this changes the behaviour of the scope such that it doesn't return places with an explicit null value, but that's really what it should be doing anyway.
