### PR TITLE
Improve reading of CSV files of unknown charset

### DIFF
--- a/test/fixtures/encodings/windows-1252.csv
+++ b/test/fixtures/encodings/windows-1252.csv
@@ -1,0 +1,2 @@
+name,address1,address2,town,postcode,access_notes,general_notes,url,email,phone,fax,text_phone
+1 Stop Instrüction™,Power League,Forest Road,Ilford (Fairlop),IG6 3HJ,Some access notes,Some general notes,http://www.1stopinstruction.com,info@1stopinstruction.com,0800 848 8418,0800 848 8419,0800 848 8420

--- a/test/unit/data_set_test.rb
+++ b/test/unit/data_set_test.rb
@@ -91,29 +91,36 @@ class DataSetTest < ActiveSupport::TestCase
       end
 
       should "handle ASCII files" do
-        @ds.data_file = File.open(fixture_file_path('encodings/ascii.csv'))
+        @ds.data_file = File.open(fixture_file_path('encodings/ascii.csv'), :encoding => 'ascii-8bit')
         @ds.save!
         expected = File.read(fixture_file_path('encodings/ascii.csv'))
         assert_equal expected, @ds.csv_data
       end
 
       should "handle UTF-8 files" do
-        @ds.data_file = File.open(fixture_file_path('encodings/utf-8.csv'))
+        @ds.data_file = File.open(fixture_file_path('encodings/utf-8.csv'), :encoding => 'ascii-8bit')
         @ds.save!
         expected = File.read(fixture_file_path('encodings/utf-8.csv'))
         assert_equal expected, @ds.csv_data
       end
 
       should "handle ISO-8859-1 files" do
-        @ds.data_file = File.open(fixture_file_path('encodings/iso-8859-1.csv'))
+        @ds.data_file = File.open(fixture_file_path('encodings/iso-8859-1.csv'), :encoding => 'ascii-8bit')
         @ds.save!
         expected = File.read(fixture_file_path('encodings/iso-8859-1.csv')).force_encoding('iso-8859-1').encode('utf-8')
         assert_equal expected, @ds.csv_data
       end
 
+      should "handle Windows 1252 files" do
+        @ds.data_file = File.open(fixture_file_path('encodings/windows-1252.csv'), :encoding => 'ascii-8bit')
+        @ds.save!
+        expected = File.read(fixture_file_path('encodings/windows-1252.csv')).force_encoding('windows-1252').encode('utf-8')
+        assert_equal expected, @ds.csv_data
+      end
+
       should "raise an error with an unknown file encoding" do
         assert_raise InvalidCharacterEncodingError do
-          @ds.data_file = File.open(fixture_file_path('encodings/utf-16le.csv'))
+          @ds.data_file = File.open(fixture_file_path('encodings/utf-16le.csv'), :encoding => 'ascii-8bit')
         end
       end
     end


### PR DESCRIPTION
This should now work correctly with utf-8 and windows-1252 (and therefore iso-8859-1) encoded CSV files.
