### PR TITLE
Facet label fix

### DIFF
--- a/app/views/admin/business_support_schemes/_facets.html.erb
+++ b/app/views/admin/business_support_schemes/_facets.html.erb
@@ -5,8 +5,8 @@
   </label>
   <% collection.each do |facet| -%>
     <label class="checkbox inline">
-    <%= f.check_box model_collection, { :multiple => true }, facet.slug, nil %>
-    <%= facet.name %>
-  </label>
+      <%= f.check_box model_collection, { :multiple => true }, facet.slug, nil %>
+      <%= facet.name %>
+    </label>
   <% end %>
 </div>


### PR DESCRIPTION
Clicking the label next to a facet checkbox didn't work for me in chromium so here's a fix.
