### PR TITLE
Expose facet values for schemes.

### DIFF
--- a/app/controllers/business_support_schemes_controller.rb
+++ b/app/controllers/business_support_schemes_controller.rb
@@ -11,7 +11,7 @@ class BusinessSupportSchemesController < ApplicationController
       schemes = BusinessSupportScheme.for_relations(relations)
     end 
     @count = schemes.size
-    @schemes_json = schemes.to_json(only: [:business_support_identifier, :title, :priority]) 
+    @schemes_json = schemes.to_json(only: [:business_support_identifier, :title, :priority, :business_sizes, :locations, :sectors, :stages, :support_types]) 
     respond_to do |format|
       format.json
     end

--- a/test/functional/business_support_schemes_controller_test.rb
+++ b/test/functional/business_support_schemes_controller_test.rb
@@ -86,6 +86,9 @@ class BusinessSupportSchemesControllerTest < ActionController::TestCase
     results = JSON.parse(response.body)['results']
     assert_equal "Urban Development Grant", results.first['title']
     assert_equal 2, results.first['priority']
+    assert_equal ['loan'], results.first['support_types']
+    assert_equal ['wales'], results.first['locations']
+    assert_equal ['under-10'], results.first['business_sizes']
   end
   
   test "GET to index with no sectors param" do


### PR DESCRIPTION
From [this story](https://www.pivotaltracker.com/story/show/57646218)
Enhancements to business-support-finder frontend rely on the facet values
for each scheme being present in imminence results.
