### PR TITLE
Disable spherical coordinates geoNear query option.

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -136,12 +136,12 @@ class Place
     opts = {
       "geoNear" => "places",
       "near" => [location.longitude, location.latitude],
-      "spherical" => true,
+      "spherical" => false,
       "query" => extra_query
     }
 
     if distance
-      opts["maxDistance"] = distance.in(:radians)
+      opts["maxDistance"] = distance.in(:degrees)
     end
 
     if limit
@@ -151,7 +151,7 @@ class Place
     response = Mongoid.master.command(opts)
     response["results"].collect do |result|
       Mongoid::Factory.from_db(self, result["obj"]).tap do |doc|
-        doc.dis = Distance.new(result["dis"], :radians)
+        doc.dis = Distance.new(result["dis"], :degrees)
       end
     end
   end

--- a/test/integration/place_calculations_test.rb
+++ b/test/integration/place_calculations_test.rb
@@ -39,8 +39,8 @@ class PlaceCalculationsTest < ActionDispatch::IntegrationTest
     assert_equal expected_places, places.to_a
 
     # Check that the distances are reported correctly
-    distances_in_miles = [0, 1.425, 331]
-    places.to_a.zip(distances_in_miles).each do |place, expected_distance|
+    expected_distances_in_miles = [0, 1.82, 373]
+    places.to_a.zip(expected_distances_in_miles).each do |place, expected_distance|
       assert_in_epsilon expected_distance, place.dis.in(:miles), 0.01
     end
 
@@ -54,7 +54,7 @@ class PlaceCalculationsTest < ActionDispatch::IntegrationTest
     places = service.data_sets.last.places_near(centre, Distance.miles(1.42))
     assert_equal 1, places.length
 
-    places = service.data_sets.last.places_near(centre, Distance.miles(1.43))
+    places = service.data_sets.last.places_near(centre, Distance.miles(1.83))
     assert_equal 2, places.length
   end
 
@@ -66,7 +66,7 @@ class PlaceCalculationsTest < ActionDispatch::IntegrationTest
     places = service.data_sets.last.places_near(centre, Distance.miles(330))
     assert_equal 2, places.length
 
-    places = service.data_sets.last.places_near(centre, Distance.miles(335))
+    places = service.data_sets.last.places_near(centre, Distance.miles(373))
     assert_equal 3, places.length
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/60089402
MongoDB 2.0 does not support indexes using a spherical coordinate system.
Until now we have not been using the index because it is not compatible with a spherical query.
This changes the geoNear query to use a cartesian distance calculation which is compatible with the existing index.
We had to change the unit tests to take into account the different distance values calculated using this new coordinate system.

We tested spherical and non-spherical options on geoNear queries:

```
spherical: true        time: 954ms
spherical: false       time: 349ms
```
