### PR TITLE
Restore default production asset config.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,6 +50,19 @@ Imminence::Application.configure do
   config.action_mailer.default_url_options = { :host => Plek.current.find('imminence') }
   config.action_mailer.delivery_method = :ses
 
+  # Compress JavaScripts and CSS
+  config.assets.compress = true
+
+  # Choose the compressors to use
+  # config.assets.js_compressor  = :uglifier
+  # config.assets.css_compressor = :yui
+
+  # Don't fallback to assets pipeline if a precompiled asset is missed
+  config.assets.compile = false
+
+  # Generate digests for assets URLs.
+  config.assets.digest = true
+
   # Enable JSON-style logging
   config.logstasher.enabled = true
   config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")


### PR DESCRIPTION
This is the default for new Rails projects.

It's absence here (specifically the `config.assets.compile` entry) was masking another problem where the assets weren't being compiled at deploy time. Requests for assets were therefore falling through to Rails, and being compiled on the fly.

This depends on alphagov-deployment#395
