### PR TITLE
Add areas endpoint for specific area types.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'formtastic-bootstrap', git: 'https://github.com/cgunther/formtastic-bootstr
 gem 'jquery-rails'
 gem 'less-rails-bootstrap'
 
-gem 'gds-api-adapters', '8.2.1'
+gem 'gds-api-adapters', '10.13.0'
 gem 'statsd-ruby', '1.0.0', :require => 'statsd'
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     faye-websocket (0.4.6)
       eventmachine (>= 0.12.0)
     ffi (1.3.1)
-    gds-api-adapters (8.2.1)
+    gds-api-adapters (10.13.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -324,7 +324,7 @@ DEPENDENCIES
   faraday (= 0.8.1)
   formtastic!
   formtastic-bootstrap!
-  gds-api-adapters (= 8.2.1)
+  gds-api-adapters (= 10.13.0)
   gds-sso (= 9.2.0)
   govspeak (~> 1.2)
   inherited_resources

--- a/app/controllers/areas_controller.rb
+++ b/app/controllers/areas_controller.rb
@@ -1,0 +1,9 @@
+class AreasController < ApplicationController
+  def index
+    api_response = Imminence.mapit_api.areas_for_type(params[:area_type])
+    @presenter = AreasPresenter.new(api_response)
+    respond_to do |format|
+      format.json { render :json => @presenter.present.to_json }
+    end
+  end
+end

--- a/app/presenters/areas_presenter.rb
+++ b/app/presenters/areas_presenter.rb
@@ -1,0 +1,41 @@
+class AreasPresenter
+
+  def initialize(api_response)
+    @status = api_response.code
+    @areas = api_response.to_hash.values
+  end
+
+  def present
+    {
+      "_response_info" => {
+        "status" => response_status,
+        "links" => []
+      },
+      "total" => @areas.size,
+      "start_index" => 1,
+      "page_size" => @areas.size,
+      "current_page" => 1,
+      "pages" => 1,
+      "results" => @areas.map { |a| area_attrs(a) }
+    }
+  end
+
+  private
+
+    def response_status
+      if @status == 200
+        "ok"
+      else
+        @status
+      end
+    end
+
+    def area_attrs(area)
+      {
+        "id" => area["id"],
+        "name" => area["name"],
+        "country_name" => area["country_name"]
+      }
+    end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Imminence::Application.routes.draw do
     root :to => 'services#index'
   end
 
+  get '/areas/:area_type', :to => 'areas#index', :constraints => { :area_type => /EUR|CTY|DIS|LBO/ }
+
   resources :business_support_schemes, :only => :index
   resources :data_sets, :only => :show
   resources :places, :only => :show

--- a/test/functional/areas_controller_test.rb
+++ b/test/functional/areas_controller_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class AreasControllerTest < ActionController::TestCase
+  test "the index action responds successfully" do
+    Imminence.mapit_api.stubs(:areas_for_type).returns(
+      OpenStruct.new(:code => 200, :to_hash => {
+      '123' => { 'name' => 'Narnia County Council' },
+      '234' => { 'name' => 'Toytown District Council' }
+    }))
+    get :index, { :area_type => 'CTY', :format => :json }
+
+    assert_equal 200, response.status
+
+    response_hash = assigns(:presenter).present
+
+    assert_equal "ok", response_hash["_response_info"]["status"]
+    assert_equal 2, response_hash["results"].size
+    assert_equal "Narnia County Council", response_hash["results"].first["name"]
+    assert_equal "Toytown District Council", response_hash["results"].last["name"]
+  end
+
+  test "only permitted area types are successfully routed" do
+    assert_raise ActionController::RoutingError do
+      get :index, { :area_type => 'FOO' }
+    end
+  end
+end


### PR DESCRIPTION
Expose a subset of Mapit area data for specific types of area (EUR, CTY, DIS, LBO, roughly equivalent to Region, County and Local Authority). Part of [this story](https://www.pivotaltracker.com/story/show/64384982)
