### PR TITLE
Bump gds-sso to 9.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ if ENV['BUNDLE_DEV']
 else
   gem 'gds-sso', '9.3.0'
 end
-gem "faraday", "0.8.1" # Specifying to resolve Jenkins dependency resolution fail
 
 gem 'govspeak', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,6 @@ DEPENDENCIES
   exception_notification (= 2.5.2)
   factory_girl (= 3.3.0)
   factory_girl_rails
-  faraday (= 0.8.1)
   formtastic!
   formtastic-bootstrap!
   gds-api-adapters (= 10.13.0)


### PR DESCRIPTION
This is to fix an issue with transfer ot bearer tokens. See
https://github.com/alphagov/signonotron2/pull/245 for details.

Also tidied up some details in the Gemfile (redundant source, and gem pinning)
