### PR TITLE
Add missing require to DataSetsController

### DIFF
--- a/app/controllers/admin/data_sets_controller.rb
+++ b/app/controllers/admin/data_sets_controller.rb
@@ -1,4 +1,5 @@
 require "csv"
+require "imminence/file_verifier"
 
 class Admin::DataSetsController < InheritedResources::Base
   include Admin::AdminControllerMixin


### PR DESCRIPTION
This was causing occasional errors in dev.  Given this class references
this lib, it should be required here.
