### PR TITLE
Leave the Eastern EUR area alone

### DIFF
--- a/lib/mapit_api.rb
+++ b/lib/mapit_api.rb
@@ -46,9 +46,6 @@ module MapitApi
     private
 
     def normalise_regions(regions)
-      eastern_index = regions.index { |r| r["name"] == "Eastern" }
-      regions[eastern_index]["name"] = "East of England" if eastern_index
-
       regions.unshift({ "name" => "England", "country_name" => "England", "type" => "EUR" })
     end
   end

--- a/test/unit/lib/mapit_api_test.rb
+++ b/test/unit/lib/mapit_api_test.rb
@@ -86,14 +86,6 @@ class MapitApiTest < ActiveSupport::TestCase
         assert_equal "Westminster City Council", response.payload[:areas].second["name"]
         assert_equal "London", response.payload[:areas].last["name"]
       end
-      should "normalise region names" do
-        @areas[444] = { "name" => "Eastern" }
-        api_response = MockResponse.new(200, @areas)
-        response = MapitApi::RegionsResponse.new(api_response)
-
-        assert_equal 200, response.payload[:code]
-        assert_equal "East of England", response.payload[:areas].last["name"]
-      end
     end
     context "payload for an AreasByPostcodeResponse" do
       should "return code and areas attributes in a hash" do


### PR DESCRIPTION
Related to [this PR](https://github.com/alphagov/publisher/pull/327) though not dependent on it.
Don't modify the `eastern` area slug returned from Mapit. 
