### PR TITLE
No need to set SECRET_KEY_BASE_DUMMY here.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY . .
 RUN bootsnap precompile --gemfile .
-RUN SECRET_KEY_BASE_DUMMY=1 rails assets:precompile && rm -fr log
+RUN rails assets:precompile && rm -fr log
 
 
 FROM --platform=$TARGETPLATFORM $base_image


### PR DESCRIPTION
govuk-ruby-builder image [already sets this](https://github.com/alphagov/govuk-ruby-images/blob/6cd1b32/builder.Dockerfile#L16) these days.