### PR TITLE
Remove dependency on uglifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "sentry-sidekiq"
 gem "sprockets-rails"
 gem "state_machines"
 gem "state_machines-activerecord"
-gem "uglifier"
 
 group :development, :test do
   gem "database_cleaner-active_record"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,6 @@ GEM
       rubocop
       smart_properties
     erubi (1.13.0)
-    execjs (2.8.1)
     expgen (0.1.1)
       parslet
     factory_bot (6.4.5)
@@ -783,8 +782,6 @@ GEM
       sync
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     uri (0.13.0)
     version_gem (1.1.4)
@@ -842,7 +839,6 @@ DEPENDENCIES
   sprockets-rails
   state_machines
   state_machines-activerecord
-  uglifier
   webmock
 
 RUBY VERSION


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Remove dependency on uglifier for asset compression.

- needed to be swapped out for terser ahead of the govuk-frontend v5 upgrade, but doesn't appear to be in use
- assets.compile is false, where it would normally use uglifier

## Visual changes
None.

Trello card: https://trello.com/c/qc60GqSG/195-changes-to-applications-for-the-govuk-frontend-v5-upgrade