### PR TITLE
Handle items that are in search but not content-store gracefully

### DIFF
--- a/app/services/govuk_site_lookup_service.rb
+++ b/app/services/govuk_site_lookup_service.rb
@@ -20,6 +20,8 @@ class GovukSiteLookupService
         ci = content_store_api.content_item(pp["link"])
         slug = ci["details"]["place_type"]
         hash[slug] = { link: Plek.website_root + pp["link"], title: pp["title"] }
+      rescue GdsApi::HTTPNotFound => e
+        Rails.logger.warn("Search result for place does not exist in content store: #{e}")
       end
     end
   end

--- a/spec/services/govuk_site_lookup_service_spec.rb
+++ b/spec/services/govuk_site_lookup_service_spec.rb
@@ -1,11 +1,13 @@
 require "rails_helper"
 
 RSpec.describe(GovukSiteLookupService, type: :model) do
+  let(:search_results) { { results: [{ title: "Test Service", link: "/test-service-page" }] } }
+
   before do
-    search_results = { results: [{ title: "Test Service", link: "/test-service-page" }] }
     stub_request(:get, "http://search-api.dev.gov.uk/search.json?count=200&fields=title,link&filter_format=place").to_return(status: 200, body: search_results.to_json, headers: {})
     content_item = { details: { place_type: "test-service" } }
     stub_request(:get, "http://content-store.dev.gov.uk/content/test-service-page").to_return(status: 200, body: content_item.to_json, headers: {})
+    stub_request(:get, "http://content-store.dev.gov.uk/content/foooo").to_return(status: 404, body: "", headers: {})
   end
 
   describe "#govuk_page?" do
@@ -26,6 +28,14 @@ RSpec.describe(GovukSiteLookupService, type: :model) do
 
   describe "#page_title" do
     it "returns title of frontend page" do
+      expect(GovukSiteLookupService.new.page_title("test-service")).to(eq("Test Service"))
+    end
+  end
+
+  context "with items that are in search but missing from content-store" do
+    let(:search_results) { { results: [{ title: "foo", link: "/foooo" }, { title: "Test Service", link: "/test-service-page" }] } }
+
+    it "returns title of frontend page, ignoring the broken item" do
       expect(GovukSiteLookupService.new.page_title("test-service")).to(eq("Test Service"))
     end
   end


### PR DESCRIPTION
Fixes problems like this in Integration:
https://govuk.sentry.io/issues/5786122859/?project=4507265355022336&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0

..in which search returns a place item that doesn't exist in the content store. We just gracefully ignore those, since they're not valid place items and won't link to a service.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
