### PR TITLE
Update ApplicationController - Remove protect_from_forgery code

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,3 @@
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :null_session
-
   include GDS::SSO::ControllerMethods
 end


### PR DESCRIPTION
- The app does not include endpoints related to form-submission.In this context, CSRF protection is not actually valid and hence we could safely remove this line and avoid unnecessary alerts.

Ref alert: https://github.com/alphagov/places-manager/security/code-scanning/1

Trello https://trello.com/c/1OOXWIkI/594-security-alert-for-csrf-protection-weakened-or-disabled

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
