### PR TITLE
[PNP-9925] Add RailsCache and SidekiqRedis healthchecks

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::ActiveRecord,
+    GovukHealthcheck::RailsCache,
+    GovukHealthcheck::SidekiqRedis,
   )
 
   namespace :admin do


### PR DESCRIPTION
We use caching in the [GovukSiteLookupService](https://github.com/alphagov/places-manager/blob/main/app/services/govuk_site_lookup_service.rb#L15) class and have [Sidekiq workers](https://github.com/alphagov/places-manager/tree/main/app/workers) to run different jobs,
so we should monitor the health and availability of these services.

These basic healthchecks are already available from `govuk_app_config` - see https://github.com/alphagov/govuk_app_config/blob/main/docs/healthchecks.md

[Jira card](https://gov-uk.atlassian.net/browse/PNP-9925)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
