### PR TITLE
[PNP-9961] Pin SHAs for third-party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.305.0
+        uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
         with:
           bundler-cache: true
 
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.305.0
+        uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
         with:
           bundler-cache: true
 
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.305.0
+        uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
         with:
           bundler-cache: true
 

--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: alphagov/places-manager
           ref: ${{ inputs.ref }}
-      - uses: ruby/setup-ruby@v1.305.0
+      - uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
         with:
           bundler-cache: true
       - run: bundle exec rails db:setup


### PR DESCRIPTION
Pin non-alphagov/non-github actions

-As per policy: https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#pin-untrusted-github-actions-to-a-commit-sha

JIRA Card: https://gov-uk.atlassian.net/browse/PNP-9961
