### PR TITLE
Add map properties to Places

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -22,6 +22,8 @@ class Place < ApplicationRecord
 
   validates :service_slug, presence: true
   validates :data_set_version, presence: true
+  validates :map_marker_colour, length: { maximum: 32 }
+  validates :map_marker_symbol, length: { maximum: 32 }
   validates :source_address, presence: true
   validates :postcode, presence: true
   validates :override_lat, numericality: { allow_blank: true }

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -123,6 +123,8 @@ class Place < ApplicationRecord
       text_phone: row["text_phone"],
       source_address: row["source_address"] || "#{row['address1']} #{row['address2']} #{row['town']} #{row['postcode']}",
       gss: row["gss"],
+      map_marker_colour: row["map_marker_colour"],
+      map_marker_symbol: row["map_marker_symbol"],
     }
     location_parameters = if row["lng"] && row["lat"]
                             { override_lng: row["lng"], override_lat: row["lat"] }

--- a/app/presenters/data_set_csv_presenter.rb
+++ b/app/presenters/data_set_csv_presenter.rb
@@ -1,7 +1,7 @@
 require "csv"
 
 class DataSetCsvPresenter
-  COLUMN_NAMES = %w[service_slug data_set_version name source_address address1 address2 town postcode access_notes general_notes url email phone fax text_phone geocode_error gss lng lat].freeze
+  COLUMN_NAMES = %w[service_slug data_set_version name source_address address1 address2 town postcode access_notes general_notes url email phone fax text_phone geocode_error gss lng lat map_marker_colour map_marker_symbol].freeze
 
   def initialize(data_set)
     @data_set = data_set

--- a/app/presenters/place_presenter.rb
+++ b/app/presenters/place_presenter.rb
@@ -26,6 +26,8 @@ class PlacePresenter
       { field: "GSS", value: place.gss },
       { field: "Source Address", value: place.source_address },
       { field: "Last Updated", value: place.updated_at },
+      { field: "Map Marker Colour", value: place.map_marker_colour },
+      { field: "Map Marker Symbol", value: place.map_marker_symbol },
     ]
 
     { items: summary_items }

--- a/app/views/admin/data_sets/_file_help.html.erb
+++ b/app/views/admin/data_sets/_file_help.html.erb
@@ -7,8 +7,9 @@
 <p class="govuk-body">
 These columns will be imported (any others will be ignored):</p>
 <blockquote class="govuk-body">
-  <strong>name</strong> | <strong>source_address</strong> | <strong>address1</strong> | <strong>address2</strong> | <strong>town</strong> | <strong>postcode</strong> | <strong>access_notes</strong> | <strong>general_notes</strong> | <strong>url</strong> | <strong>email</strong> | <strong>phone</strong> | <strong>fax</strong> | <strong>text_phone</strong> | <strong>gss</strong> | <strong>lng</strong> | <strong>lat</strong>
+  <strong>name</strong> | <strong>source_address</strong> | <strong>address1</strong> | <strong>address2</strong> | <strong>town</strong> | <strong>postcode</strong> | <strong>access_notes</strong> | <strong>general_notes</strong> | <strong>url</strong> | <strong>email</strong> | <strong>phone</strong> | <strong>fax</strong> | <strong>text_phone</strong> | <strong>gss</strong> | <strong>lng</strong> | <strong>lat</strong> | <strong>map_marker_colour</strong> | <strong>map_marker_symbol</strong>
 </blockquote class="govuk-body">
 <p class="govuk-body">
 Use <strong>lng</strong> and <strong>lat</strong> to override the location for a place instead of using the postcode's location.
+Note: <strong>map_marker_colour</strong> and <strong>map_marker_symbol</strong> columns are currently experimental and do not need to be filled in.
 </p>

--- a/db/migrate/20260430102924_add_map_properties_to_places.rb
+++ b/db/migrate/20260430102924_add_map_properties_to_places.rb
@@ -1,0 +1,8 @@
+class AddMapPropertiesToPlaces < ActiveRecord::Migration[8.1]
+  def change
+    change_table :places, bulk: true do |t|
+      t.string :map_marker_symbol
+      t.string :map_marker_colour
+    end
+  end
+end

--- a/db/migrate/20260430144316_add_map_properties_to_place_archives.rb
+++ b/db/migrate/20260430144316_add_map_properties_to_place_archives.rb
@@ -1,0 +1,8 @@
+class AddMapPropertiesToPlaceArchives < ActiveRecord::Migration[8.1]
+  def change
+    change_table :place_archives, bulk: true do |t|
+      t.string :map_marker_symbol
+      t.string :map_marker_colour
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2024_03_06_155313) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_30_102924) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "postgis"
@@ -85,6 +85,8 @@ ActiveRecord::Schema[8.1].define(version: 2024_03_06_155313) do
     t.string "geocode_error"
     t.string "gss"
     t.geography "location", limit: {srid: 4326, type: "st_point", geographic: true}
+    t.string "map_marker_colour"
+    t.string "map_marker_symbol"
     t.string "name"
     t.float "override_lat"
     t.float "override_lng"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_30_102924) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_30_144316) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "postgis"
@@ -60,6 +60,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_102924) do
     t.string "geocode_error"
     t.string "gss"
     t.geography "location", limit: {srid: 4326, type: "st_point", geographic: true}
+    t.string "map_marker_colour"
+    t.string "map_marker_symbol"
     t.string "name"
     t.float "override_lat"
     t.float "override_lng"

--- a/spec/fixtures/good_csv.csv
+++ b/spec/fixtures/good_csv.csv
@@ -1,2 +1,2 @@
-name,address1,address2,town,postcode,access_notes,general_notes,url,email,phone,fax,text_phone
-1 Stop Instruction,Power League,Forest Road,Ilford (Fairlop),IG6 3HJ,Some access notes,Some general notes,http://www.1stopinstruction.com,info@1stopinstruction.com,0800 848 8418,0800 848 8419,0800 848 8420
+name,address1,address2,town,postcode,access_notes,general_notes,url,email,phone,fax,text_phone,map_marker_colour,map_marker_symbol
+1 Stop Instruction,Power League,Forest Road,Ilford (Fairlop),IG6 3HJ,Some access notes,Some general notes,http://www.1stopinstruction.com,info@1stopinstruction.com,0800 848 8418,0800 848 8419,0800 848 8420,blue,square

--- a/spec/functional/admin/data_sets_controller_spec.rb
+++ b/spec/functional/admin/data_sets_controller_spec.rb
@@ -35,6 +35,8 @@ module Admin
           expect(place.phone).to(eq("0800 848 8418"))
           expect(place.fax).to(eq("0800 848 8419"))
           expect(place.text_phone).to(eq("0800 848 8420"))
+          expect(place.map_marker_colour).to(eq("blue"))
+          expect(place.map_marker_symbol).to(eq("square"))
         end
       end
 

--- a/spec/integration/admin/data_set_create_spec.rb
+++ b/spec/integration/admin/data_set_create_spec.rb
@@ -91,5 +91,19 @@ RSpec.describe("DataSetCreateEditTest", type: :integration) do
       expect(place.override_lat).to(eq(51.599123456789))
       expect(place.override_lng).to(eq(0.10033123456789))
     end
+
+    it "creates a dataset from csv with map markers" do
+      stub_locations_api_has_location("IG6 3HJ", [{ "latitude" => 51.59918278577261, "longitude" => 0.10033740198112132 }])
+      visit("/admin/services/#{@service.id}")
+      click_link("Upload new data set")
+      attach_file("Upload a file", fixture_file_path("good_csv.csv"))
+      click_button("Upload")
+
+      @service.reload
+      ds = @service.latest_data_set
+      place = ds.places.first
+      expect(place.map_marker_colour).to(eq("blue"))
+      expect(place.map_marker_symbol).to(eq("square"))
+    end
   end
 end

--- a/spec/integration/places_api_spec.rb
+++ b/spec/integration/places_api_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe("Places API", type: :integration) do
       @data_set2 = @service.data_sets.create!
       @place_1a = FactoryBot.create(:place, service_slug: @service.slug, data_set_version: @data_set1.version, latitude: 51.613314, longitude: -0.158278, name: "Town Hall")
       @place_1b = FactoryBot.create(:place, service_slug: @service.slug, data_set_version: @data_set1.version, latitude: 51.500728, longitude: -0.124626, name: "Palace of Westminster")
-      @place_2a = FactoryBot.create(:place, service_slug: @service.slug, data_set_version: @data_set2.version, latitude: 51.613314, longitude: -0.158278, name: "Town Hall 2")
-      @place_2b = FactoryBot.create(:place, service_slug: @service.slug, data_set_version: @data_set2.version, latitude: 51.500728, longitude: -0.124626, name: "Palace of Westminster 2")
+      @place_2a = FactoryBot.create(:place, service_slug: @service.slug, data_set_version: @data_set2.version, latitude: 51.613314, longitude: -0.158278, name: "Town Hall 2", map_marker_colour: "blue", map_marker_symbol: "circle")
+      @place_2b = FactoryBot.create(:place, service_slug: @service.slug, data_set_version: @data_set2.version, latitude: 51.500728, longitude: -0.124626, name: "Palace of Westminster 2", map_marker_colour: "red", map_marker_symbol: "square")
       @data_set2.activate
     end
 
@@ -25,6 +25,13 @@ RSpec.describe("Places API", type: :integration) do
       expect(page.response_headers["Content-Type"]).to(eq("application/json; charset=utf-8"))
       data = JSON.parse(page.body)
       expect(data["places"].map { |p| p["name"] }).to(eq(["Palace of Westminster 2", "Town Hall 2"]))
+    end
+
+    it "returns the map markers in the places as JSON" do
+      visit("/places/#{@service.slug}.json")
+      data = JSON.parse(page.body)
+      expect(data["places"].map { |p| p["map_marker_colour"] }).to(eq(%w[red blue]))
+      expect(data["places"].map { |p| p["map_marker_symbol"] }).to(eq(%w[square circle]))
     end
 
     it "returns all places as CSV" do

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -119,4 +119,50 @@ RSpec.describe(Place, type: :model) do
       assert_in_epsilon(0.491351, p.dis.in(:miles), 0.001)
     end
   end
+
+  context "map markers" do
+    before do
+      @place = FactoryBot.create(:place)
+    end
+
+    it "returns the default value of null for map_marker_symbol" do
+      expect(@place.map_marker_symbol).to be_nil
+    end
+
+    it "returns the default value of null for map_marker_colour" do
+      expect(@place.map_marker_colour).to be_nil
+    end
+
+    it "accepts a maximum char length of 32 for map_marker_symbol" do
+      s = Service.first
+      s.data_sets.create!(version: 2)
+      @place.data_set_version = 2
+      @place.map_marker_symbol = "a" * 32
+
+      expect(@place.valid?).to be true
+    end
+
+    it "accepts a maximum char length of 32 for map_marker_colour" do
+      s = Service.first
+      s.data_sets.create!(version: 2)
+      @place.data_set_version = 2
+      @place.map_marker_colour = "a" * 32
+
+      expect(@place.valid?).to be true
+    end
+
+    it "does not accept a string of more than 32 chars for map_marker_symbol" do
+      @place.map_marker_symbol = "a" * 33
+
+      expect(@place).not_to be_valid
+      expect(@place.errors[:base].present?).to(eq(true))
+    end
+
+    it "does not accept a string of more than 32 chars for map_marker_colour" do
+      @place.map_marker_colour = "a" * 33
+
+      expect(@place).not_to be_valid
+      expect(@place.errors[:base].present?).to(eq(true))
+    end
+  end
 end

--- a/spec/presenters/data_set_csv_presenter_spec.rb
+++ b/spec/presenters/data_set_csv_presenter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe(DataSetCsvPresenter, type: :model) do
   let(:result) { data_set_csv_presenter.to_csv }
 
   def expected_header_row
-    "service_slug,data_set_version,name,source_address,address1,address2,town,postcode,access_notes,general_notes,url,email,phone,fax,text_phone,geocode_error,gss,lng,lat"
+    "service_slug,data_set_version,name,source_address,address1,address2,town,postcode,access_notes,general_notes,url,email,phone,fax,text_phone,geocode_error,gss,lng,lat,map_marker_colour,map_marker_symbol"
   end
 
   context "presenting an empty data set" do
@@ -17,10 +17,10 @@ RSpec.describe(DataSetCsvPresenter, type: :model) do
   end
 
   context "presenting a data set with a place" do
-    let(:place) { FactoryBot.create(:place, service_slug: service.slug, data_set_version: data_set.version, email: "camden@example.com", gss: "00AG", override_lng: 0.0, override_lat: 1.0) }
+    let(:place) { FactoryBot.create(:place, service_slug: service.slug, data_set_version: data_set.version, email: "camden@example.com", gss: "00AG", override_lng: 0.0, override_lat: 1.0, map_marker_colour: "red", map_marker_symbol: "circle") }
 
     it "contain a header row and a results row" do
-      expected_place_row = "#{service.slug},2,CosaNostra Pizza #3569,\"#{place.address1}, Los Angeles, WC2B 6NH\",#{place.address1},,Los Angeles,WC2B 6NH,,,,camden@example.com,01234 567890,,,,00AG,0.0,1.0"
+      expected_place_row = "#{service.slug},2,CosaNostra Pizza #3569,\"#{place.address1}, Los Angeles, WC2B 6NH\",#{place.address1},,Los Angeles,WC2B 6NH,,,,camden@example.com,01234 567890,,,,00AG,0.0,1.0,red,circle"
 
       expect(result.split("\n").size).to(eq(2))
       expect(result.split("\n").first).to(eq(expected_header_row))


### PR DESCRIPTION
- Add new map marker properties `map_marker_symbol` and `map_marker_colour` to `places` and `place_archives`

[JIRA ticket](https://gov-uk.atlassian.net/browse/PNP-9956)

Collaborator: @deborahchua

## Screenshots

In Upload new data set - Map marker fields added with note
| Before | After |
|-------|--------|
|<img width="820" height="590" alt="image" src="https://github.com/user-attachments/assets/120e8cb0-3ca6-4620-a2e7-bee79b768428" />|<img width="776" height="661" alt="image" src="https://github.com/user-attachments/assets/e1f8a8b9-024b-45f0-87c3-fdec41904cda" />|

After uploading the dataset with the map marker properties

<img width="588" height="886" alt="image" src="https://github.com/user-attachments/assets/1d380f6d-f89f-4bc2-b661-5cf23fd62239" />


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
