### PR TITLE
Fix SimpleCov deprecation warning

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,8 +4,8 @@ require "simplecov"
 SimpleCov.start "rails" do
   enable_coverage :branch
   minimum_coverage line: 90
-  add_filter "lib/tasks/cucumber.rake"
-  add_filter "lib/tasks/lint.rake"
+  skip "lib/tasks/cucumber.rake"
+  skip "lib/tasks/lint.rake"
 end
 
 require File.expand_path("../config/environment", __dir__)


### PR DESCRIPTION
This fixes:

```
/govuk/places-manager/spec/rails_helper.rb:7:in 'block in <top (required)>': [DEPRECATION] `SimpleCov.add_filter` is deprecated. Replace with `SimpleCov.skip` (same arguments, same behavior). Example: `SimpleCov.skip "lib/tasks/cucumber.rake"`.
/govuk/places-manager/spec/rails_helper.rb:8:in 'block in <top (required)>': [DEPRECATION] `SimpleCov.add_filter` is deprecated. Replace with `SimpleCov.skip` (same arguments, same behavior). Example: `SimpleCov.skip "lib/tasks/lint.rake"`.
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
