### PR TITLE
Add VS debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "state_machines-activerecord"
 
 group :development, :test do
   gem "database_cleaner-active_record"
+  gem "debug"
   gem "erb_lint", require: false
   gem "pact", "~> 1.67", require: false
   gem "pact_broker-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,9 @@ GEM
       database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
     date (3.5.1)
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.6.2)
     dig_rb (1.0.1)
     domain_name (0.6.20240107)
@@ -336,7 +339,6 @@ GEM
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2026.0701)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -359,9 +361,6 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.5)
-    nokogiri (1.19.4)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.4-arm64-darwin)
@@ -872,7 +871,6 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin
-  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -882,6 +880,7 @@ DEPENDENCIES
   cucumber-rails
   dartsass-rails
   database_cleaner-active_record
+  debug
   erb_lint
   factory_bot_rails
   gds-api-adapters

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-do
 ```sh
 bundle exec rake
 ```
+### Debugging support
+
+See [Debugging](docs/debugging-in-vs-code.md)
 
 ## Licence
 

--- a/config/initializers/debug.rb
+++ b/config/initializers/debug.rb
@@ -1,0 +1,6 @@
+if Rails.env.development? && ENV["VIRTUAL_HOST"]
+  require "debug/session"
+  Rails.logger.info "Starting debug session"
+  # the port can be anything
+  DEBUGGER__.open(port: "12345", host: "0.0.0.0")
+end

--- a/docs/debugging-in-vs-code.md
+++ b/docs/debugging-in-vs-code.md
@@ -1,0 +1,25 @@
+# Debugging in VS Code
+
+If you want to debug within VS Code, you'll need the [VSCode rdbg Ruby Debugger](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) extension, and once that's installed, create a configuration file for it at `.vscode/launch.json` containing the following values
+
+```
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "rdbg",
+      "name": "Attach with rdbg",
+      "request": "attach",
+      "debugPort": "places-manager.dev.gov.uk:12349",
+      "localfsMap": "/:${userHome}"
+    }
+  ]
+}
+```
+
+Then run govuk-docker-up, and use the Run and Debug tab and press the play button next to "Attach with rdbg", at which point you'll be able to set breakpoints in your code.
+
+Note: the magic number in the debugPort setting should match the equivalent one in govuk-docker for feedback (by default the debug port creates itself at 12345, but to avoid clashes if running more than one app, we redirect that port to different numbers on the host)


### PR DESCRIPTION
Adds vs code debugging support to places-manager with govuk-docker (see https://github.com/alphagov/govuk-docker/pull/1023)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
